### PR TITLE
Charge Port Open Clarification

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -331,7 +331,7 @@ Resets the PIN set for valet mode, if set.
             }
 
 ## Open Charge Port [POST /api/1/vehicles/{vehicle_id}/command/charge_port_door_open]
-Opens the charge port. Does not close the charge port (for now...)
+Opens the charge port. Does not close the charge port (for now...). This endpoint also unlocks the charge port if it's locked.
 
 + Request
     + Headers


### PR DESCRIPTION
Clarify that the charge port open endpoint can also be used to unlock the charge port